### PR TITLE
refactor: centralize configuration handling

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,78 @@
+import copy
+from importlib import metadata
+from pathlib import Path
+
+import yaml
+
+# Global configuration and headers
+cfg: dict = {}
+HEADERS: dict = {}
+
+
+def load_config(path: str = "config.yaml") -> dict:
+    """Load configuration from *path* and refresh HEADERS."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    cfg.clear()
+    if data:
+        cfg.update(data)
+    refresh_headers_from_cfg()
+    return cfg
+
+
+def save_config(config: dict, path: str = "config.yaml") -> None:
+    """Persist *config* to *path* and refresh HEADERS."""
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(config, f, allow_unicode=True, sort_keys=False)
+    cfg.clear()
+    cfg.update(config)
+    refresh_headers_from_cfg()
+
+
+def refresh_headers_from_cfg() -> None:
+    """Refresh HEADERS using values from global cfg."""
+    HEADERS.clear()
+    headers = copy.deepcopy(cfg.get("headers", {})) if cfg else {}
+    cookie = cfg.get("cookie") if cfg else None
+    if cookie:
+        headers["Cookie"] = cookie
+    HEADERS.update(headers)
+
+
+def check_requirements(req_file: str = "requirements.txt") -> bool:
+    """Check whether required packages are installed.
+
+    Returns True if all requirements are satisfied, False otherwise.
+    """
+    req_path = Path(req_file)
+    if not req_path.exists():
+        print(f"警告：未找到 {req_file}，跳过依赖检查")
+        return True
+
+    with open(req_path, encoding="utf-8") as f:
+        requirements = [r.strip() for r in f.read().splitlines() if r.strip() and not r.startswith("#")]
+
+    missing_packages = []
+    for req in requirements:
+        try:
+            if ">=" in req:
+                pkg_name, version_required = req.split(">=", 1)
+                installed_version = metadata.version(pkg_name)
+                if installed_version < version_required:
+                    raise metadata.PackageNotFoundError
+            elif "==" in req:
+                pkg_name, version_required = req.split("==", 1)
+                installed_version = metadata.version(pkg_name)
+                if installed_version != version_required:
+                    raise metadata.PackageNotFoundError
+            else:
+                metadata.version(req)
+        except metadata.PackageNotFoundError:
+            missing_packages.append(req)
+
+    if missing_packages:
+        print("缺少依赖或版本不匹配：")
+        for pkg in missing_packages:
+            print(f"  - {pkg}")
+        return False
+    return True


### PR DESCRIPTION
## Summary
- centralize config loading, saving, and requirement checks in new `config.py`
- reuse shared config and headers in `download.py` and `download-ui.py`

## Testing
- `python -m py_compile config.py download.py download-ui.py`


------
https://chatgpt.com/codex/tasks/task_e_689f0ac4c1bc832a96ab21676b2568df