### PR TITLE
feat: centralize network requests

### DIFF
--- a/download-ui.py
+++ b/download-ui.py
@@ -13,8 +13,8 @@ from urllib.parse import urljoin
 
 import requests
 import yaml
-from requests.adapters import HTTPAdapter
-from urllib3 import Retry
+
+from network import safe_get
 
 from config import (
     HEADERS,
@@ -42,22 +42,6 @@ except FileNotFoundError:
 except yaml.YAMLError as e:
     print(f"配置文件格式错误: {e}")
     sys.exit(1)
-
-session = requests.Session()
-retry_strategy = Retry(
-    total=5,
-    backoff_factor=1,
-    status_forcelist=[500, 502, 503, 504],
-    allowed_methods=["HEAD", "GET", "OPTIONS"],
-    raise_on_status=False
-)
-adapter = HTTPAdapter(max_retries=retry_strategy)
-session.mount("http://", adapter)
-session.mount("https://", adapter)
-
-
-def safe_get(url_1, **kwargs):
-    return session.get(url_1, timeout=10, **kwargs)
 
 
 # 入口前检查依赖 & ffmpeg

--- a/download.py
+++ b/download.py
@@ -6,9 +6,9 @@ from urllib.parse import urljoin
 
 import requests
 import yaml
-from requests.adapters import HTTPAdapter
 from tqdm import tqdm
-from urllib3 import Retry
+
+from network import safe_get
 
 from config import HEADERS, cfg, check_requirements, load_config
 
@@ -23,22 +23,6 @@ except yaml.YAMLError as e:
     exit(1)
 
 import sys
-
-session = requests.Session()
-retry_strategy = Retry(
-    total=5,  # 总重试次数
-    backoff_factor=1,  # 重试延迟递增 (1s, 2s, 4s...)
-    status_forcelist=[500, 502, 503, 504],
-    allowed_methods=["HEAD", "GET", "OPTIONS"],
-    raise_on_status=False
-)
-adapter = HTTPAdapter(max_retries=retry_strategy)
-session.mount("http://", adapter)
-session.mount("https://", adapter)
-
-
-def safe_get(url_1, **kwargs):
-    return session.get(url_1, timeout=10, **kwargs)
 
 
 # 入口前检查依赖

--- a/network.py
+++ b/network.py
@@ -1,0 +1,39 @@
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3 import Retry
+
+
+def _create_session() -> requests.Session:
+    """Create and configure a requests Session with retry strategy."""
+    session = requests.Session()
+    retry_strategy = Retry(
+        total=5,
+        backoff_factor=1,
+        status_forcelist=[500, 502, 503, 504],
+        allowed_methods=["HEAD", "GET", "OPTIONS"],
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
+
+_session = None
+
+
+def get_session() -> requests.Session:
+    """Return a shared Session instance."""
+    global _session
+    if _session is None:
+        _session = _create_session()
+    return _session
+
+
+# Singleton session for modules that prefer direct access
+session = get_session()
+
+
+def safe_get(url: str, **kwargs):
+    """Wrapper around session.get with default timeout."""
+    return get_session().get(url, timeout=10, **kwargs)


### PR DESCRIPTION
## Summary
- add shared network module with retry-aware `requests.Session` and `safe_get`
- update download scripts to reuse network session

## Testing
- `python -m py_compile network.py download.py download-ui.py`


------
https://chatgpt.com/codex/tasks/task_e_689f5f2abfd4832a9eaaf2f515f43fe5