### PR TITLE
Centralize download utilities

### DIFF
--- a/download-ui.py
+++ b/download-ui.py
@@ -2,29 +2,32 @@
 # 基于你现有脚本改造：提供GUI选择账号与帖子后再下载
 import copy
 import os
-import re
-import shutil
-import subprocess
 import threading
 import queue
 import sys
-import time
-from urllib.parse import urljoin
 
-import requests
 import yaml
 
-from network import safe_get
-from api import (get_subscription_list, parse_subscription_list, get_user_info_by_code, get_timeline)
+from api import (
+    get_subscription_list,
+    parse_subscription_list,
+    get_user_info_by_code,
+    get_timeline,
+)
 
 from config import (
-    HEADERS,
     cfg,
     check_requirements,
     load_config,
     refresh_headers_from_cfg,
     save_config,
 )
+
+try:
+    from downloader import sanitize_filename, download_and_merge
+except RuntimeError as e:
+    print(f"错误：{e}")
+    sys.exit(1)
 
 # === GUI ===
 import tkinter as tk
@@ -45,182 +48,6 @@ except yaml.YAMLError as e:
     sys.exit(1)
 
 
-# 入口前检查依赖 & ffmpeg
-ffmpeg_path = shutil.which("ffmpeg")
-if ffmpeg_path is None:
-    print("错误：未找到 ffmpeg。请先安装 ffmpeg 并确保其在系统 PATH 中。")
-    sys.exit(1)
-
-
-# 清理文件名中的非法字符
-def sanitize_filename(filename):
-    return re.sub(r'[<>:"/\\|?*]', '_', filename).strip()
-
-
-# 创建目录
-def ensure_dir(path):
-    os.makedirs(path, exist_ok=True)
-
-
-# 下载并合并（增加 log/progress 回调，GUI 中不用 tqdm）
-def download_and_merge(file_url, target_dir, output_name, url_type='m3u8',
-                       log=None, pause_event=None, cancel_event=None, on_ffmpeg=None):
-    """
-    on_ffmpeg(proc): 回调当前 ffmpeg Popen 进程（开始时传入进程对象，结束/异常时传入 None），便于 GUI 取消时终止。
-    pause_event: threading.Event，置位(set)代表运行，clear 代表暂停。各下载循环会调用 wait() 自阻塞。
-    cancel_event: threading.Event，一旦 set 立即中止所有后续步骤。
-    """
-
-    def _log(msg):
-        if log:
-            log(msg)
-        else:
-            print(msg)
-
-    def _wait_if_paused():
-        if pause_event is not None:
-            # wait()：暂停时阻塞，继续时立即返回
-            pause_event.wait()
-
-    def _should_cancel():
-        return (cancel_event is not None) and cancel_event.is_set()
-
-    ensure_dir(target_dir)
-
-    # ---------- 直下 mp4 ----------
-    if url_type == 'mp4':
-        output_path = os.path.join(target_dir, output_name)
-        _log(f"[下载 MP4] {output_path}")
-        resp = safe_get(file_url, headers=HEADERS, stream=True)
-        resp.raise_for_status()
-        total_size = int(resp.headers.get("content-length", 0)) or None
-        downloaded = 0
-        with open(output_path, "wb") as f:
-            for chunk in resp.iter_content(1024 * 1024):
-                if _should_cancel():
-                    _log("[取消] 用户已取消（mp4）。")
-                    raise RuntimeError("Cancelled")
-                _wait_if_paused()
-                if chunk:
-                    f.write(chunk)
-                    downloaded += len(chunk)
-                    if total_size:
-                        _log(f"[进度] {output_name}: {downloaded * 100 // total_size}%")
-        _log(f"[下载完成] {output_path}")
-        return None
-
-    # ---------- m3u8 ----------
-    r = safe_get(file_url, headers=HEADERS)
-    r.raise_for_status()
-    m3u8_text = r.text
-    m3u8_filename = os.path.join(target_dir, os.path.basename(file_url))
-    with open(m3u8_filename, "w", encoding="utf-8") as f:
-        f.write(m3u8_text)
-
-    lines = [l.strip() for l in m3u8_text.splitlines() if l.strip()]
-    if any(l.startswith("#EXT-X-STREAM-INF") for l in lines):
-        for i, l in enumerate(lines):
-            if l.startswith("#EXT-X-STREAM-INF"):
-                sub_1 = lines[i + 1]
-                base = file_url.rsplit("/", 1)[0] + "/"
-                sub_url = sub_1 if sub_1.startswith("http") else urljoin(base, sub_1)
-                return download_and_merge(
-                    sub_url, target_dir, output_name, 'm3u8',
-                    log=log, pause_event=pause_event, cancel_event=cancel_event, on_ffmpeg=on_ffmpeg
-                )
-
-    # 解析 TS 列表
-    base = file_url.rsplit("/", 1)[0] + "/"
-    ts_urls = [(l if l.startswith("http") else urljoin(base, l)) for l in lines if not l.startswith("#")]
-
-    # 下载 TS 并生成合并列表
-    filelist_path = os.path.join(target_dir, "filelist.txt")
-    with open(filelist_path, "w", encoding="utf-8") as list_f:
-        total = len(ts_urls)
-        for idx, ts in enumerate(ts_urls):
-            if _should_cancel():
-                _log("[取消] 用户已取消（TS 列表下载前）。")
-                raise RuntimeError("Cancelled")
-            _wait_if_paused()
-
-            ts_name = f"{idx:04d}.ts"
-            ts_path = os.path.join(target_dir, ts_name)
-            try:
-                resp = safe_get(ts, headers=HEADERS, stream=True)
-                resp.raise_for_status()
-            except requests.exceptions.SSLError as e:
-                _log(f"[重试中] TS {idx} SSL 错误: {e}")
-                resp = safe_get(ts, headers=HEADERS, stream=True)
-                resp.raise_for_status()
-
-            with open(ts_path, "wb") as ts_f:
-                for chunk in resp.iter_content(1024 * 1024):
-                    if _should_cancel():
-                        _log("[取消] 用户已取消（TS 下载中）。")
-                        raise RuntimeError("Cancelled")
-                    _wait_if_paused()
-                    if chunk:
-                        ts_f.write(chunk)
-
-            list_f.write(f"file '{ts_name}'\n")
-            _log(f"[TS] {idx + 1}/{total}")
-
-    # 合并 TS -> ffmpeg
-    output_path = os.path.join(target_dir, output_name)
-
-    def _run_ffmpeg(cmd):
-        p = None
-        try:
-            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-            if on_ffmpeg:
-                on_ffmpeg(p)
-            # 轮询，支持取消/暂停
-            while True:
-                if _should_cancel():
-                    _log("[取消] 终止 FFmpeg 进程...")
-                    try:
-                        p.terminate()
-                    except Exception:
-                        pass
-                    try:
-                        p.wait(timeout=5)
-                    except Exception:
-                        try:
-                            p.kill()
-                        except Exception:
-                            pass
-                    raise RuntimeError("Cancelled")
-
-                _wait_if_paused()
-
-                ret = p.poll()
-                if ret is not None:
-                    if ret != 0:
-                        raise subprocess.CalledProcessError(ret, cmd)
-                    break
-                time.sleep(0.2)
-        finally:
-            if on_ffmpeg:
-                on_ffmpeg(None)
-
-    try:
-        cmd = [ffmpeg_path, "-y", "-f", "concat", "-safe", "0", "-i", filelist_path,
-               "-c", "copy", "-ignore_unknown", "-fflags", "+genpts", output_path]
-        _run_ffmpeg(cmd)
-    except subprocess.CalledProcessError as e:
-        _log(f"警告：FFmpeg 合并失败，尝试重新编码: {e}")
-        cmd = [ffmpeg_path, "-y", "-f", "concat", "-safe", "0", "-i", filelist_path,
-               "-c:v", "libx264", "-c:a", "aac", "-ignore_unknown", "-fflags", "+genpts", output_path]
-        _run_ffmpeg(cmd)
-
-    _log(f"[合并完成] {output_path}")
-
-    # 清理中间文件
-    for filename in os.listdir(target_dir):
-        if filename.endswith(".ts") or filename.endswith(".m3u8") or filename == "filelist.txt":
-            os.remove(os.path.join(target_dir, filename))
-    _log(f"[清理] 中间文件已删除")
-    return None
 
 
 # ----------------- GUI 应用 -----------------

--- a/download.py
+++ b/download.py
@@ -1,135 +1,32 @@
 import os
-import re
-import shutil
-import subprocess
-from urllib.parse import urljoin
+import sys
 
-import requests
 import yaml
-from tqdm import tqdm
 
-from network import safe_get
-from api import (get_subscription_list, parse_subscription_list, get_user_info_by_code, get_timeline)
+from api import (
+    get_subscription_list,
+    parse_subscription_list,
+    get_user_info_by_code,
+    get_timeline,
+)
 
-from config import HEADERS, cfg, check_requirements, load_config
+from config import cfg, check_requirements, load_config
+
+try:
+    from downloader import sanitize_filename, download_and_merge
+except RuntimeError as e:
+    print(f"错误：{e}")
+    sys.exit(1)
 
 
 try:
     load_config()
 except FileNotFoundError:
     print("错误：未找到 config.yaml")
-    exit(1)
+    sys.exit(1)
 except yaml.YAMLError as e:
     print(f"配置文件格式错误: {e}")
-    exit(1)
-
-import sys
-
-
-# 入口前检查依赖
-ffmpeg_path = shutil.which("ffmpeg")
-if ffmpeg_path is None:
-    print("错误：未找到 ffmpeg。请先安装 ffmpeg 并确保其在系统 PATH 中。")
-    exit(1)
-
-
-# 清理文件名中的非法字符
-def sanitize_filename(filename):
-    return re.sub(r'[<>:"/\\|?*]', '_', filename).strip()
-
-
-# 创建目录
-def ensure_dir(path):
-    os.makedirs(path, exist_ok=True)
-
-
-# 下载并合并函数
-def download_and_merge(file_url, target_dir, output_name, url_type='m3u8'):
-    ensure_dir(target_dir)
-
-    # 如果是mp4文件，直接下载
-    if url_type == 'mp4':
-        output_path = os.path.join(target_dir, output_name)
-        print(f"[下载 MP4] {output_path}")
-        resp = safe_get(file_url, headers=HEADERS, stream=True)
-        resp.raise_for_status()
-        total_size = int(resp.headers.get("content-length", 0))
-        with open(output_path, "wb") as f, tqdm(
-                total=total_size, unit='B', unit_scale=True, desc=output_name
-        ) as pbar:
-            for chunk in resp.iter_content(1024 * 1024):
-                if chunk:
-                    f.write(chunk)
-                    pbar.update(len(chunk))
-        print(f"[下载完成] {output_path}")
-        return None
-
-    # 下载 m3u8 文本
-    r = safe_get(file_url, headers=HEADERS)
-    r.raise_for_status()
-    m3u8_text = r.text
-    m3u8_filename = os.path.join(target_dir, os.path.basename(file_url))
-    with open(m3u8_filename, "w", encoding="utf-8") as f:
-        f.write(m3u8_text)
-
-    # 判断 Master Playlist
-    lines = [l.strip() for l in m3u8_text.splitlines() if l.strip()]
-    if any(l.startswith("#EXT-X-STREAM-INF") for l in lines):
-        for i, l in enumerate(lines):
-            if l.startswith("#EXT-X-STREAM-INF"):
-                sub_1 = lines[i + 1]
-                base = file_url.rsplit("/", 1)[0] + "/"
-                sub_url = sub_1 if sub_1.startswith("http") else urljoin(base, sub_1)
-                return download_and_merge(sub_url, target_dir, output_name)
-
-    # 解析 TS 列表
-    base = file_url.rsplit("/", 1)[0] + "/"
-    ts_urls = [(l if l.startswith("http") else urljoin(base, l)) for l in lines if not l.startswith("#")]
-
-    # 下载 TS 并生成合并列表
-    filelist_path = os.path.join(target_dir, "filelist.txt")
-    with open(filelist_path, "w", encoding="utf-8") as list_f:
-        with tqdm(total=len(ts_urls), unit='ts', desc="TS 下载") as pbar:
-            for idx, ts in enumerate(ts_urls):
-                ts_name = f"{idx:04d}.ts"
-                ts_path = os.path.join(target_dir, ts_name)
-                try:
-                    resp = safe_get(ts, headers=HEADERS, stream=True)
-                    resp.raise_for_status()
-                except requests.exceptions.SSLError as e:
-                    print(f"[重试中] TS {idx} SSL 错误: {e}")
-                    resp = safe_get(ts, headers=HEADERS, stream=True)
-                    resp.raise_for_status()
-                with open(ts_path, "wb") as ts_f:
-                    for chunk in resp.iter_content(1024 * 1024):
-                        if chunk:
-                            ts_f.write(chunk)
-                list_f.write(f"file '{ts_name}'\n")
-                pbar.update(1)
-
-    # 合并 TS
-    output_path = os.path.join(target_dir, output_name)
-    cmd = [ffmpeg_path, "-y", "-f", "concat", "-safe", "0", "-i", filelist_path,
-           "-c", "copy", "-ignore_unknown", "-fflags", "+genpts", output_path]
-    try:
-        subprocess.run(cmd, check=True)
-    except subprocess.CalledProcessError as e:
-        print(f"警告：FFmpeg 合并失败，尝试使用重新编码方式: {e}")
-        cmd = [ffmpeg_path, "-y", "-f", "concat", "-safe", "0", "-i", filelist_path,
-               "-c:v", "libx264", "-c:a", "aac", "-ignore_unknown", "-fflags", "+genpts", output_path]
-        try:
-            subprocess.run(cmd, check=True)
-        except subprocess.CalledProcessError as e:
-            print(f"错误：FFmpeg 重新编码也失败了: {e}")
-            raise
-    print(f"[合并完成] {output_path}")
-
-    # 清理中间文件
-    for filename in os.listdir(target_dir):
-        if filename.endswith(".ts") or filename.endswith(".m3u8") or filename == "filelist.txt":
-            os.remove(os.path.join(target_dir, filename))
-    print(f"[清理] 中间文件已删除")
-    return None
+    sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/downloader.py
+++ b/downloader.py
@@ -1,0 +1,285 @@
+import os
+import re
+import shutil
+import subprocess
+import time
+from urllib.parse import urljoin
+
+import requests
+from tqdm import tqdm
+
+from network import safe_get
+from config import HEADERS
+
+ffmpeg_path = shutil.which("ffmpeg")
+if ffmpeg_path is None:
+    raise RuntimeError("未找到 ffmpeg。请先安装 ffmpeg 并确保其在系统 PATH 中。")
+
+
+def sanitize_filename(filename: str) -> str:
+    """Replace characters invalid on most filesystems."""
+    return re.sub(r'[<>:"/\\|?*]', '_', filename).strip()
+
+
+def ensure_dir(path: str) -> None:
+    """Create directory if it does not exist."""
+    os.makedirs(path, exist_ok=True)
+
+
+def download_and_merge(
+    file_url: str,
+    target_dir: str,
+    output_name: str,
+    url_type: str = "m3u8",
+    log=None,
+    pause_event=None,
+    cancel_event=None,
+    on_ffmpeg=None,
+):
+    """Download a video (m3u8/mp4) and merge segments via ffmpeg.
+
+    Parameters
+    ----------
+    file_url: str
+        URL to the video file or m3u8 playlist.
+    target_dir: str
+        Directory to store temporary files and final output.
+    output_name: str
+        Name of the resulting mp4 file.
+    url_type: str
+        Either "m3u8" or "mp4".
+    log: callable, optional
+        Logging function; defaults to ``print`` when omitted.
+    pause_event: threading.Event, optional
+        When provided, download will pause while the event is cleared.
+    cancel_event: threading.Event, optional
+        When set, the download is cancelled immediately.
+    on_ffmpeg: callable, optional
+        Callback receiving the ffmpeg ``Popen`` object. Called with ``None``
+        when processing ends.
+    """
+
+    def _log(msg):
+        if log:
+            log(msg)
+        else:
+            print(msg)
+
+    def _wait_if_paused():
+        if pause_event is not None:
+            pause_event.wait()
+
+    def _should_cancel():
+        return cancel_event is not None and cancel_event.is_set()
+
+    ensure_dir(target_dir)
+
+    # ---- direct mp4 ----
+    if url_type == "mp4":
+        output_path = os.path.join(target_dir, output_name)
+        _log(f"[下载 MP4] {output_path}")
+        resp = safe_get(file_url, headers=HEADERS, stream=True)
+        resp.raise_for_status()
+        total_size = int(resp.headers.get("content-length", 0)) or None
+        with open(output_path, "wb") as f:
+            if log is None:
+                with tqdm(total=total_size or 0, unit="B", unit_scale=True, desc=output_name) as pbar:
+                    for chunk in resp.iter_content(1024 * 1024):
+                        if _should_cancel():
+                            _log("[取消] 用户已取消（mp4）。")
+                            raise RuntimeError("Cancelled")
+                        _wait_if_paused()
+                        if chunk:
+                            f.write(chunk)
+                            pbar.update(len(chunk))
+            else:
+                downloaded = 0
+                for chunk in resp.iter_content(1024 * 1024):
+                    if _should_cancel():
+                        _log("[取消] 用户已取消（mp4）。")
+                        raise RuntimeError("Cancelled")
+                    _wait_if_paused()
+                    if chunk:
+                        f.write(chunk)
+                        downloaded += len(chunk)
+                        if total_size:
+                            _log(f"[进度] {output_name}: {downloaded * 100 // total_size}%")
+        _log(f"[下载完成] {output_path}")
+        return None
+
+    # ---- m3u8 playlist ----
+    r = safe_get(file_url, headers=HEADERS)
+    r.raise_for_status()
+    m3u8_text = r.text
+    m3u8_filename = os.path.join(target_dir, os.path.basename(file_url))
+    with open(m3u8_filename, "w", encoding="utf-8") as f:
+        f.write(m3u8_text)
+
+    lines = [l.strip() for l in m3u8_text.splitlines() if l.strip()]
+    if any(l.startswith("#EXT-X-STREAM-INF") for l in lines):
+        for i, l in enumerate(lines):
+            if l.startswith("#EXT-X-STREAM-INF"):
+                sub_1 = lines[i + 1]
+                base = file_url.rsplit("/", 1)[0] + "/"
+                sub_url = sub_1 if sub_1.startswith("http") else urljoin(base, sub_1)
+                return download_and_merge(
+                    sub_url,
+                    target_dir,
+                    output_name,
+                    "m3u8",
+                    log=log,
+                    pause_event=pause_event,
+                    cancel_event=cancel_event,
+                    on_ffmpeg=on_ffmpeg,
+                )
+
+    base = file_url.rsplit("/", 1)[0] + "/"
+    ts_urls = [
+        (l if l.startswith("http") else urljoin(base, l))
+        for l in lines
+        if not l.startswith("#")
+    ]
+
+    filelist_path = os.path.join(target_dir, "filelist.txt")
+    with open(filelist_path, "w", encoding="utf-8") as list_f:
+        total = len(ts_urls)
+        if log is None:
+            with tqdm(total=total, unit="ts", desc="TS 下载") as pbar:
+                for idx, ts in enumerate(ts_urls):
+                    if _should_cancel():
+                        _log("[取消] 用户已取消（TS 列表下载前）。")
+                        raise RuntimeError("Cancelled")
+                    _wait_if_paused()
+
+                    ts_name = f"{idx:04d}.ts"
+                    ts_path = os.path.join(target_dir, ts_name)
+                    try:
+                        resp = safe_get(ts, headers=HEADERS, stream=True)
+                        resp.raise_for_status()
+                    except requests.exceptions.SSLError as e:
+                        _log(f"[重试中] TS {idx} SSL 错误: {e}")
+                        resp = safe_get(ts, headers=HEADERS, stream=True)
+                        resp.raise_for_status()
+
+                    with open(ts_path, "wb") as ts_f:
+                        for chunk in resp.iter_content(1024 * 1024):
+                            if _should_cancel():
+                                _log("[取消] 用户已取消（TS 下载中）。")
+                                raise RuntimeError("Cancelled")
+                            _wait_if_paused()
+                            if chunk:
+                                ts_f.write(chunk)
+                    list_f.write(f"file '{ts_name}'\n")
+                    pbar.update(1)
+        else:
+            for idx, ts in enumerate(ts_urls):
+                if _should_cancel():
+                    _log("[取消] 用户已取消（TS 列表下载前）。")
+                    raise RuntimeError("Cancelled")
+                _wait_if_paused()
+
+                ts_name = f"{idx:04d}.ts"
+                ts_path = os.path.join(target_dir, ts_name)
+                try:
+                    resp = safe_get(ts, headers=HEADERS, stream=True)
+                    resp.raise_for_status()
+                except requests.exceptions.SSLError as e:
+                    _log(f"[重试中] TS {idx} SSL 错误: {e}")
+                    resp = safe_get(ts, headers=HEADERS, stream=True)
+                    resp.raise_for_status()
+
+                with open(ts_path, "wb") as ts_f:
+                    for chunk in resp.iter_content(1024 * 1024):
+                        if _should_cancel():
+                            _log("[取消] 用户已取消（TS 下载中）。")
+                            raise RuntimeError("Cancelled")
+                        _wait_if_paused()
+                        if chunk:
+                            ts_f.write(chunk)
+                list_f.write(f"file '{ts_name}'\n")
+                _log(f"[TS] {idx + 1}/{total}")
+
+    output_path = os.path.join(target_dir, output_name)
+
+    def _run_ffmpeg(cmd):
+        if log is None and pause_event is None and cancel_event is None and on_ffmpeg is None:
+            subprocess.run(cmd, check=True)
+        else:
+            p = None
+            try:
+                p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                if on_ffmpeg:
+                    on_ffmpeg(p)
+                while True:
+                    if _should_cancel():
+                        _log("[取消] 终止 FFmpeg 进程...")
+                        try:
+                            p.terminate()
+                        except Exception:
+                            pass
+                        try:
+                            p.wait(timeout=5)
+                        except Exception:
+                            try:
+                                p.kill()
+                            except Exception:
+                                pass
+                        raise RuntimeError("Cancelled")
+                    _wait_if_paused()
+                    ret = p.poll()
+                    if ret is not None:
+                        if ret != 0:
+                            raise subprocess.CalledProcessError(ret, cmd)
+                        break
+                    time.sleep(0.2)
+            finally:
+                if on_ffmpeg:
+                    on_ffmpeg(None)
+
+    try:
+        cmd = [
+            ffmpeg_path,
+            "-y",
+            "-f",
+            "concat",
+            "-safe",
+            "0",
+            "-i",
+            filelist_path,
+            "-c",
+            "copy",
+            "-ignore_unknown",
+            "-fflags",
+            "+genpts",
+            output_path,
+        ]
+        _run_ffmpeg(cmd)
+    except subprocess.CalledProcessError as e:
+        _log(f"警告：FFmpeg 合并失败，尝试重新编码: {e}")
+        cmd = [
+            ffmpeg_path,
+            "-y",
+            "-f",
+            "concat",
+            "-safe",
+            "0",
+            "-i",
+            filelist_path,
+            "-c:v",
+            "libx264",
+            "-c:a",
+            "aac",
+            "-ignore_unknown",
+            "-fflags",
+            "+genpts",
+            output_path,
+        ]
+        _run_ffmpeg(cmd)
+
+    _log(f"[合并完成] {output_path}")
+
+    for filename in os.listdir(target_dir):
+        if filename.endswith(".ts") or filename.endswith(".m3u8") or filename == "filelist.txt":
+            os.remove(os.path.join(target_dir, filename))
+    _log(f"[清理] 中间文件已删除")
+    return None


### PR DESCRIPTION
## Summary
- Move download helpers into new `downloader` module with optional logging and pause/cancel hooks
- Update CLI and GUI entry points to use shared downloader functions
- Clean up redundant imports

## Testing
- `python -m py_compile downloader.py download.py download-ui.py`


------
https://chatgpt.com/codex/tasks/task_e_689f6269659c832a8ecc11303e82b189