### PR TITLE
refactor: modularize GUI entry

### DIFF
--- a/download-ui.py
+++ b/download-ui.py
@@ -1,27 +1,6 @@
-import sys
-import yaml
+"""Entry point script for launching the GUI application."""
 
-from config import check_requirements, load_config
-from gui import DownloaderGUI
-
-
-def main():
-    try:
-        load_config()
-    except FileNotFoundError:
-        print("错误：未找到 config.yaml")
-        sys.exit(1)
-    except yaml.YAMLError as e:
-        print(f"配置文件格式错误: {e}")
-        sys.exit(1)
-
-    if not check_requirements():
-        print("\n请先安装缺少的依赖：")
-        print("pip install -r requirements.txt")
-        sys.exit(1)
-
-    app = DownloaderGUI()
-    app.mainloop()
+from gui import DownloaderGUI, main  # noqa: F401
 
 
 if __name__ == "__main__":

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,4 +1,31 @@
+"""GUI package exposing :class:`DownloaderGUI` and a convenient :func:`main` launcher."""
+
+import sys
+import yaml
+
 from .main import DownloaderGUI
 from .config_dialog import ConfigDialog
+from config import check_requirements, load_config
 
-__all__ = ["DownloaderGUI", "ConfigDialog"]
+__all__ = ["DownloaderGUI", "ConfigDialog", "main"]
+
+
+def main() -> None:
+    """Load configuration, verify requirements and launch the GUI."""
+    try:
+        load_config()
+    except FileNotFoundError:
+        print("错误：未找到 config.yaml")
+        sys.exit(1)
+    except yaml.YAMLError as e:
+        print(f"配置文件格式错误: {e}")
+        sys.exit(1)
+
+    if not check_requirements():
+        print("\n请先安装缺少的依赖：")
+        print("pip install -r requirements.txt")
+        sys.exit(1)
+
+    app = DownloaderGUI()
+    app.mainloop()
+


### PR DESCRIPTION
## Summary
- expose a `main` launcher in the `gui` package that loads config and starts the GUI
- trim `download-ui.py` to a thin wrapper that delegates to the new launcher

## Testing
- `python -m py_compile download-ui.py gui/__init__.py`
- `python download-ui.py` *(fails: RuntimeError: 未找到 ffmpeg。请先安装 ffmpeg 并确保其在系统 PATH 中。)*

------
https://chatgpt.com/codex/tasks/task_e_689f6622e238832abe8c9581c9a46d3b